### PR TITLE
Update the README and npm commands with new Docker repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ npm run docker-push
 npm run docker-run
 ```
 
+The repository used to store the Docker image is [here](https://github.com/CerealDevelopment/CerealBot/pkgs/container/cerealbot) on Github.
+
 ## Configuration
 
 Passwords and tokens are passed with environment variables. To connect the bot to Discord a `BOT_TOKEN` is required.

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
         "clean": "rm -rf node_modules lib",
         "clean-install": "npm run-script clean && npm install",
         "clean-logs": "rm logs/*",
-        "docker-pull": "docker cerealdevelopment/cerealbot:latest",
-        "docker-build": "npm run-script build && docker build --tag cerealdevelopment/cerealbot:latest .",
-        "docker-push": "docker push cerealdevelopment/cerealbot:latest",
-        "docker-run": "docker run -d -v $(pwd)/config.json:/opt/cerealbot/config.json -v $(pwd)/data:/opt/cerealbot/data -v $(pwd)/logs:/opt/cerealbot/logs -e BOT_TOKEN=$BOT_TOKEN --name cerealbot cerealdevelopment/cerealbot:latest",
+        "docker-pull": "docker ghcr.io/cerealdevelopment/cerealbot:latest",
+        "docker-build": "npm run-script build && docker build --tag ghcr.io/cerealdevelopment/cerealbot:latest .",
+        "docker-push": "docker push ghcr.io/cerealdevelopment/cerealbot:latest",
+        "docker-run": "docker run -d -v $(pwd)/config.json:/opt/cerealbot/config.json -v $(pwd)/data:/opt/cerealbot/data -v $(pwd)/logs:/opt/cerealbot/logs -e BOT_TOKEN=$BOT_TOKEN --name cerealbot ghcr.io/cerealdevelopment/cerealbot:latest",
         "knex": "./node_modules/.bin/knex --knexfile src/data/knexfiles.ts"
     },
     "repository": {


### PR DESCRIPTION
Just a small update to the scripts and README. 

_I also deleted the old Docker hub repo. The new one can be found on Github https://github.com/CerealDevelopment/CerealBot/pkgs/container/cerealbot_

Closes #74 